### PR TITLE
fix(react-components): dateF/datetimeF가 로컬 시간대 대신 UTC를 표기하던 문제

### DIFF
--- a/modules/react-components/package.json
+++ b/modules/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonamu-kit/react-components",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "MIT",
   "author": "CartaNova <dev@cartanova.ai>",
   "repository": {

--- a/modules/react-components/src/lib/base-helpers.ts
+++ b/modules/react-components/src/lib/base-helpers.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */ // 파싱 결과이므로 any 허용
 
+import { format } from "date-fns";
 import qs from "qs";
 import { isObject } from "radashi";
 import { type z } from "zod";
@@ -70,7 +71,8 @@ export function dateF(dateValue: string | Date | null | undefined): string | nul
   if (dateValue === null || dateValue === undefined) {
     return null;
   } else if (dateValue instanceof Date) {
-    return dateValue.toISOString().slice(0, 10);
+    // toISOString은 UTC로 고정되어 로컬 시간대와 어긋난다. 로컬 기준으로 포맷한다.
+    return format(dateValue, "yyyy-MM-dd");
   } else {
     return dateValue.slice(0, 10);
   }
@@ -80,7 +82,8 @@ export function datetimeF(dateValue: string | Date | null | undefined): string |
   if (dateValue === null || dateValue === undefined) {
     return null;
   } else if (dateValue instanceof Date) {
-    return dateValue.toISOString().slice(0, 19).replace("T", " ");
+    // toISOString은 UTC로 고정되어 로컬 시간대와 어긋난다. 로컬 기준으로 포맷한다.
+    return format(dateValue, "yyyy-MM-dd HH:mm:ss");
   } else {
     return dateValue.slice(0, 19);
   }


### PR DESCRIPTION
## 문제

`dateF` / `datetimeF`가 **Date 객체**를 받으면 `toISOString()`으로 포맷해 **항상 UTC로 표기**된다. KST 환경에서는 9시간 어긋난 시각이 화면에 그대로 노출된다.

Sonamu 클라이언트는 `dateReviver`로 응답의 날짜 문자열을 **Date 객체로 변환**하므로, 실제 화면은 대부분 이 UTC 분기를 탄다.

## 회귀 경위

구 라이브러리 **react-sui는 멀쩡했다.** date-fns `format()`으로 로컬 시간대 기준 포맷을 한다.

```ts
// react-sui (정상)
return format(sqlDateStringOrDate, "yyyy-MM-dd HH:mm:ss");

// react-components (회귀)
return dateValue.toISOString().slice(0, 19).replace("T", " ");
```

**react-sui → react-components 포팅 과정에서 `format()`이 `toISOString()`으로 바뀌며 생긴 회귀다.**

- `6b36e8f8` (**seoyoungsz**, 2025-12-24) — react-sui 대체용 react-components 패키지를 추가하면서 UTC 구현이 처음 들어왔다. 포팅 시 동작을 보존하지 않고 임의로 바꾼 것이 원인이다.
- `c763c31d` (**seoyoungsz**, 2026-01-12) — `helpers.ts` 분리 리팩토링에서 그대로 옮겨져 유지됐다.

## 변경

react-sui와 동일하게 date-fns `format()`을 사용하도록 되돌린다. 문자열 입력 분기는 react-sui와 동일하게 유지한다.

`package.json`: `0.4.6` → `0.4.7`

## 검증 (miomock 실행 확인)

miomock에도 동일 증상이 있었으나 아무도 인지하지 못한 상태였다.

| | 표기 |
| :-- | :-- |
| DB 원본 | `2026-08-27 09:50:52+09` |
| API 응답 | `2026-08-27T09:50:52+09:00` |
| 화면 (수정 전) | `2026-08-27 00:50:52` ❌ UTC |
| 화면 (수정 후) | `2026-08-27 09:50:52` ✅ KST |

`tsc --noEmit` / oxlint / oxfmt 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)