### PR TITLE
feat(ssr): ?hmr=false로 페이지 단위 HMR 비활성화

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/api/sonamu.ts
+++ b/modules/sonamu/src/api/sonamu.ts
@@ -835,6 +835,12 @@ class SonamuClass {
           );
           template = await this.viteServer.transformIndexHtml(url, template);
 
+          // ?hmr=false로 연 페이지는 HMR 웹소켓만 끊어 새로고침되지 않게 한다.
+          const { HMR_OPT_OUT_SCRIPT, isHmrDisabledByQuery } = await import("../ssr/hmr-opt-out");
+          if (isHmrDisabledByQuery(url)) {
+            template = template.replace("<head>", `<head>\n${HMR_OPT_OUT_SCRIPT}`);
+          }
+
           reply.type("text/html");
           return template;
         } catch (e) {

--- a/modules/sonamu/src/ssr/hmr-opt-out.ts
+++ b/modules/sonamu/src/ssr/hmr-opt-out.ts
@@ -1,0 +1,78 @@
+/**
+ * 페이지 단위 HMR 비활성화(`?hmr=false`).
+ *
+ * 에이전트가 코드를 고치는 동안 사람이 보고 있는 탭이 계속 새로고침되는 것을 막기 위해,
+ * 해당 URL로 연 페이지에서만 Vite HMR을 끊는다.
+ *
+ * Vite는 페이지 단위 HMR 토글을 제공하지 않는다. `server.hmr: false`는 서버 전체에 적용되고,
+ * HTML에서 `/@vite/client` 스크립트 태그만 제거하는 방식도 통하지 않는다.
+ * 변환된 모듈마다 `import { createHotContext } from "/@vite/client"`가 들어가기 때문이다.
+ *
+ * 그래서 HMR 웹소켓 자체를 막는다. Vite HMR 소켓은 서브프로토콜로 구분되므로
+ * (`vite-hmr`, 재연결 확인은 `vite-ping`), 앱이 같은 포트에서 쓰는 웹소켓
+ * (Sonamu telemetry, ctx.ws 등)은 그대로 두고 HMR만 골라낼 수 있다.
+ *
+ * 연결 실패로 처리하지 않고 "영원히 연결 중"인 더미 소켓을 돌려주는 이유는,
+ * Vite 클라이언트가 소켓이 닫히면 재연결을 폴링하다가 성공 시 `location.reload()`를
+ * 호출하기 때문이다. close/error 이벤트를 아예 발생시키지 않아야 새로고침되지 않는다.
+ */
+
+const HMR_OPT_OUT_QUERY = "hmr";
+
+/** 요청 URL에 `?hmr=false`가 있는지 확인한다. */
+export function isHmrDisabledByQuery(url: string): boolean {
+  const queryIndex = url.indexOf("?");
+  if (queryIndex === -1) {
+    return false;
+  }
+
+  const params = new URLSearchParams(url.slice(queryIndex + 1));
+  const value = params.get(HMR_OPT_OUT_QUERY);
+  return value === "false" || value === "0";
+}
+
+/**
+ * HMR 웹소켓만 무력화하는 인라인 스크립트.
+ * 모듈 스크립트(`type="module"`)는 지연 실행되므로, 이 classic 스크립트가 항상 먼저 실행된다.
+ */
+export const HMR_OPT_OUT_SCRIPT = `<script>
+(() => {
+  var NativeWebSocket = window.WebSocket;
+  if (!NativeWebSocket) return;
+  var HMR_PROTOCOLS = ["vite-hmr", "vite-ping"];
+
+  function createIdleSocket(url) {
+    // 열리지도 닫히지도 않는 더미. close/error를 발생시키면 Vite가 재연결 후 새로고침한다.
+    return {
+      url: String(url),
+      readyState: 0,
+      protocol: "",
+      bufferedAmount: 0,
+      extensions: "",
+      binaryType: "blob",
+      onopen: null, onclose: null, onerror: null, onmessage: null,
+      addEventListener: function () {},
+      removeEventListener: function () {},
+      dispatchEvent: function () { return false; },
+      send: function () {},
+      close: function () {},
+      CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3,
+    };
+  }
+
+  window.WebSocket = new Proxy(NativeWebSocket, {
+    construct: function (Target, args) {
+      var requested = args[1];
+      var protocols = Array.isArray(requested) ? requested : requested ? [requested] : [];
+      var isHmr = protocols.some(function (protocol) {
+        return HMR_PROTOCOLS.indexOf(protocol) !== -1;
+      });
+      if (isHmr) {
+        console.info("[sonamu] hmr=false: 이 페이지의 Vite HMR 연결을 막았습니다. 변경 사항은 반영되지 않습니다.");
+        return createIdleSocket(args[0]);
+      }
+      return new Target(...args);
+    },
+  });
+})();
+</script>`;

--- a/modules/sonamu/src/ssr/renderer.ts
+++ b/modules/sonamu/src/ssr/renderer.ts
@@ -6,6 +6,7 @@ import { type ViteDevServer } from "vite";
 import { applyCacheHeaders } from "../cache-control/cache-control";
 import { type CacheControlRequest } from "../cache-control/types";
 import { type SonamuFastifyConfig } from "../types/types";
+import { HMR_OPT_OUT_SCRIPT, isHmrDisabledByQuery } from "./hmr-opt-out";
 import { type PreloadedData, type SSRRoute } from "./types";
 
 export async function renderSSR(
@@ -60,6 +61,11 @@ export async function renderSSR(
 
     // Vite가 주입한 스크립트 추출
     viteScripts = extractScriptTags(transformedHtml);
+
+    // ?hmr=false로 연 페이지는 HMR 웹소켓만 끊어 새로고침되지 않게 한다.
+    if (isHmrDisabledByQuery(url)) {
+      viteScripts = `${HMR_OPT_OUT_SCRIPT}\n${viteScripts}`;
+    }
 
     const entryModule = await vite.ssrLoadModule("/src/entry-server.generated.tsx");
     render = entryModule.render;


### PR DESCRIPTION
## 배경

에이전트가 코드를 수정하는 동안 사람이 보고 있는 탭이 계속 새로고침되어 작업이 방해받는다. 해당 URL로 연 **그 페이지에서만** Vite HMR을 끊는다.

```
http://localhost:10280/admin/tags?hmr=false
```

## 왜 이 방식인가

**Vite는 페이지 단위 HMR 토글을 제공하지 않는다.** `server.hmr: false`는 서버 전체에 적용된다.

그리고 HTML에서 `/@vite/client` 스크립트 태그만 제거하는 방식은 **통하지 않는다.** 변환된 모듈마다 클라이언트를 직접 import하기 때문이다.

```js
// GET /src/routes/admin/tags/index.tsx 응답 첫 줄
import { createHotContext as __vite__createHotContext } from "/@vite/client";
```

같은 이유로 `/@vite/client` 자체를 차단하면 모듈 import가 깨져 페이지가 아예 뜨지 않는다.

**그래서 HMR 웹소켓만 막는다.** Vite HMR 소켓은 서브프로토콜로 구분되므로(`vite-hmr`, 재연결 확인은 `vite-ping`), 앱이 같은 포트에서 쓰는 웹소켓(telemetry, `ctx.ws` 등)은 그대로 두고 HMR만 골라낼 수 있다. **HMR과 앱이 포트를 공유하는 프로젝트에서도 안전하다.**

### 더미 소켓을 쓰는 이유

연결 실패로 처리하면 안 된다. Vite 클라이언트는 소켓이 닫히면 재연결을 폴링하다 성공하면 새로고침한다.

```js
console.log(`[vite] server connection lost. Polling for restart...`);
await waitForSuccessfulPing(url.href);
location.reload();   // ← 여기로 가면 안 된다
```

그래서 close/error를 **아예 발생시키지 않는** "영원히 연결 중"(readyState 0) 더미를 돌려준다.

## 변경

- `src/ssr/hmr-opt-out.ts` (신규) — 쿼리 판별 + HMR 소켓만 가로채는 인라인 스크립트
- `src/ssr/renderer.ts` (SSR), `src/api/sonamu.ts` (CSR fallback) — `?hmr=false`일 때만 주입
- dev 경로 전용이라 프로덕션 영향 없음
- `package.json`: `0.10.12` → `0.10.13`

## 검증 (miomock, 실제 브라우저)

| 검증 | `?hmr=false` 탭 | 대조군 탭 |
| :-- | :-- | :-- |
| **dev 서버 재시작 (full reload)** | 페이지 상태 **유지** ✅ | **새로고침됨** |
| 소스 수정 | hot update 수신 **없음** | `[vite] hot updated` 수신 |
| `vite-hmr` 소켓 | 스텁 (readyState 0) | 정상 연결 |
| 일반 WebSocket | **정상 연결** (앱 영향 없음) | 정상 |

페이지 렌더·API 호출 정상. `mise run check` / `tsc --noEmit` / `test:type` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)