### PR TITLE
fix(migration): numeric의 precision/scale 누락 시 기본값으로 비교

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/migration/migration-set.ts
+++ b/modules/sonamu/src/migration/migration-set.ts
@@ -25,6 +25,10 @@ import {
 } from "../types/types";
 import { exhaustive } from "../utils/utils";
 
+// numeric 컬럼에서 precision/scale을 생략했을 때 실제로 생성되는 값(knex decimal의 기본값)이다.
+const NUMERIC_DEFAULT_PRECISION = 8;
+const NUMERIC_DEFAULT_SCALE = 2;
+
 /**
  * Entity를 읽어서 MigrationSetAndJoinTable을 만들어옵니다.
  * @param entity Entity 객체
@@ -62,11 +66,24 @@ export function getMigrationSetFromEntity(entity: Entity): MigrationSetAndJoinTa
               length: prop.length,
             }),
           // Number/Numeric 타입의 경우 precision, scale 추가
-          ...((isNumberProp(prop) || isNumericProp(prop)) && {
-            precision: prop.precision,
-            scale: prop.scale,
-            numberType: isNumberProp(prop) ? (prop.numberType ?? "numeric") : "numeric",
-          }),
+          ...((isNumberProp(prop) || isNumericProp(prop)) &&
+            (() => {
+              const numberType = isNumberProp(prop) ? (prop.numberType ?? "numeric") : "numeric";
+
+              // numeric에서 precision/scale을 생략하면 knex decimal의 기본값(8, 2)으로 컬럼이
+              // 만들어지는데, DB에서는 그 값이 그대로 읽히므로 엔티티 쪽을 undefined로 두면
+              // 매번 불일치로 잡힌다. 비교 전에 같은 기본값을 채워 실제 스키마와 맞춘다.
+              if (numberType === "numeric") {
+                return {
+                  numberType,
+                  precision: prop.precision ?? NUMERIC_DEFAULT_PRECISION,
+                  scale: prop.scale ?? NUMERIC_DEFAULT_SCALE,
+                };
+              }
+
+              // real/double precision은 precision/scale을 쓰지 않는다(DB 리더도 반환하지 않음).
+              return { numberType, precision: prop.precision, scale: prop.scale };
+            })()),
           // Vector 타입의 경우 dimensions 추가
           ...(isVectorProp(prop) && {
             dimensions: prop.dimensions,


### PR DESCRIPTION
## 문제

엔티티에 `number` 타입을 지정하면서 `precision`/`scale`을 생략하면 **매번 불일치로 잡혀 같은 alter 마이그레이션이 반복 생성**된다. (현재 엔티티 검증 단계에서는 에러가 나지 않는다.)

`decimal(col, undefined, undefined)`은 knex 기본값에 따라 `numeric(8, 2)`로 컬럼을 만드는데, DB에서는 그 값이 그대로 읽히는 반면 엔티티 쪽은 `undefined`로 남아 비교가 영영 어긋난다.

## 변경

비교 전에 knex와 동일한 기본값(`precision: 8`, `scale: 2`)을 채워 실제 스키마와 맞춘다. `numberType`은 기존에도 `"numeric"`으로 기본값이 적용되고 있었다.

`real` / `double precision`은 precision/scale을 쓰지 않고 DB 리더도 반환하지 않으므로 **numeric일 때만** 적용한다.

`package.json`: `0.11.0` → `0.11.1`

## 검증 (miomock, 실제 DB)

`{ "type": "number" }`만 지정한 프롭을 추가해서 확인:

| 단계 | 결과 |
| :-- | :-- |
| 생성되는 코드 | `decimal("score_tmp", 8, 2)` (기존: `undefined, undefined`) |
| 적용 후 DB | `numeric \| 8 \| 2` |
| 재비교 | `preparedCodes: []` ✅ |
| **수정 전 코드로 대조** | DB가 이미 `numeric(8,2)`인데도 `decimal(..., undefined, undefined)` alter를 계속 생성 ❌ |

`tsc --noEmit` / `mise run check` / `test:type` 통과. 테스트 산출물(DB 컬럼·마이그레이션·엔티티)은 모두 원복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)