### PR TITLE
perf(migration): FK 조회를 pg_constraint 직접 읽기로 전환

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/migration/postgresql-schema-reader.ts
+++ b/modules/sonamu/src/migration/postgresql-schema-reader.ts
@@ -358,26 +358,52 @@ class PostgreSQLSchemaReaderClass {
     const indexes = (await compareDB.raw(indexesQuery, [tableName])).rows;
 
     // Foreign Keys 조회
+    //
+    // information_schema(table_constraints × key_column_usage × constraint_column_usage
+    // × referential_constraints) 4중 조인 대신 pg_constraint를 직접 읽는다.
+    // constraint_column_usage는 뷰 안으로 테이블 필터가 밀려들어가지 않아 DB 전체의
+    // 제약조건을 훑는다. 제약이 조금만 많아져도 테이블 하나 조회에 1초 이상 걸리고,
+    // 비교는 테이블마다 이 쿼리를 돌리므로 전체 소요가 급격히 커진다.
+    // contype='f' 인덱스 스캔으로 바꾸면 NOT NULL 제약(PG 17+에서 pg_constraint에
+    // 기록된다) 등을 아예 건너뛴다.
+    //
+    // conkey/confkey는 컬럼 순서를 담은 배열이므로 WITH ORDINALITY로 같은 순번끼리
+    // 짝지어야 복합 FK에서 컬럼 대응이 어긋나지 않는다.
     const foreignsQuery = `
       SELECT
-        tc.constraint_name,
-        kcu.column_name,
-        ccu.table_name AS foreign_table_name,
-        ccu.column_name AS foreign_column_name,
-        rc.update_rule,
-        rc.delete_rule
-      FROM information_schema.table_constraints AS tc
-      JOIN information_schema.key_column_usage AS kcu
-        ON tc.constraint_name = kcu.constraint_name
-        AND tc.table_schema = kcu.table_schema
-      JOIN information_schema.constraint_column_usage AS ccu
-        ON ccu.constraint_name = tc.constraint_name
-        AND ccu.table_schema = tc.table_schema
-      JOIN information_schema.referential_constraints AS rc
-        ON rc.constraint_name = tc.constraint_name
-        AND rc.constraint_schema = tc.table_schema
-      WHERE tc.constraint_type = 'FOREIGN KEY'
-        AND tc.table_name = ?
+        con.conname AS constraint_name,
+        att.attname AS column_name,
+        ref_cl.relname AS foreign_table_name,
+        ref_att.attname AS foreign_column_name,
+        CASE con.confupdtype
+          WHEN 'a' THEN 'NO ACTION'
+          WHEN 'r' THEN 'RESTRICT'
+          WHEN 'c' THEN 'CASCADE'
+          WHEN 'n' THEN 'SET NULL'
+          WHEN 'd' THEN 'SET DEFAULT'
+        END AS update_rule,
+        CASE con.confdeltype
+          WHEN 'a' THEN 'NO ACTION'
+          WHEN 'r' THEN 'RESTRICT'
+          WHEN 'c' THEN 'CASCADE'
+          WHEN 'n' THEN 'SET NULL'
+          WHEN 'd' THEN 'SET DEFAULT'
+        END AS delete_rule
+      FROM pg_constraint con
+      JOIN pg_class cl ON cl.oid = con.conrelid
+      JOIN pg_namespace ns ON ns.oid = cl.relnamespace
+      JOIN pg_class ref_cl ON ref_cl.oid = con.confrelid
+      JOIN LATERAL unnest(con.conkey) WITH ORDINALITY AS key_col(attnum, ord) ON true
+      JOIN LATERAL unnest(con.confkey) WITH ORDINALITY AS ref_key_col(attnum, ord)
+        ON ref_key_col.ord = key_col.ord
+      JOIN pg_attribute att
+        ON att.attrelid = cl.oid AND att.attnum = key_col.attnum
+      JOIN pg_attribute ref_att
+        ON ref_att.attrelid = ref_cl.oid AND ref_att.attnum = ref_key_col.attnum
+      WHERE con.contype = 'f'
+        AND ns.nspname = 'public'
+        AND cl.relname = ?
+      ORDER BY con.conname, key_col.ord
     `;
     const foreigns = (await compareDB.raw(foreignsQuery, [tableName])).rows;
 


### PR DESCRIPTION
## 문제

마이그레이션 비교(`/api/migrations/prepared-codes`)가 테이블이 많은 프로젝트에서 **18초 이상** 걸렸다. 프로파일해 보면 거의 전부가 `compareMigrations`이고, 그 안에서도 **FK 조회 쿼리 하나**가 원인이다.

| 테이블당 쿼리 | 시간 (deti, 원격) |
| :-- | --: |
| 컬럼 (`information_schema.columns`) | 29ms |
| 인덱스 (pg_index 계열) | 12ms |
| **🛑 FK (information_schema 4중 조인)** | **1,231ms** |
| 벡터 차원 (pg_attribute) | 9ms |

`constraint_column_usage`는 **뷰 안으로 테이블 필터가 밀려들어가지 않아** 한 테이블만 물어봐도 DB 전체 제약조건을 훑는다. 비교는 테이블마다 이 쿼리를 돌리므로 규모가 조금만 커져도 절벽처럼 느려진다. PG 17+에서 NOT NULL이 `pg_constraint`에 기록되기 시작하며 더 나빠졌다.

| | deti | miomock |
| :-- | --: | --: |
| public 테이블 | 75 | 21 |
| pg_constraint 전체 | 872 | 359 |
| **FK 쿼리 1회** | **1,231ms** | 47ms |

제약이 2.4배인데 쿼리는 26배 — 선형이 아니다.

## 변경

`pg_constraint`를 `contype='f'`로 직접 읽는다. `information_schema` 의존 제거.

- `conkey`/`confkey`를 **`WITH ORDINALITY`로 순번을 맞춰 짝지음** → 기존 쿼리가 `constraint_name`으로만 조인해 복합 FK에서 컬럼 대응이 어긋나던 문제도 해소
- `pg_class`는 스키마를 암묵적으로 걸지 않으므로 **`nspname='public'` 명시**
- 안정적인 `ORDER BY con.conname, key_col.ord`
- `confupdtype`/`confdeltype` 문자를 기존과 동일한 문자열(`NO ACTION`/`RESTRICT`/`CASCADE`/`SET NULL`/`SET DEFAULT`)로 매핑

`PgForeign` 타입과 소비부(`MigrationForeign` 매핑, 인덱스 필터링의 `constraint_name` 사용)는 **그대로**다.

## 측정 (deti, 원격 DB, 75테이블)

| | 구 (information_schema) | 신 (pg_constraint) |
| :-- | --: | --: |
| 75테이블 직렬 | **62.97s** | **1.79s** |
| 테이블당 | ~1,231ms | ~30ms |

**약 35배.** 4병렬 기준 `compareMigrations` ~18s → 1초 미만이 된다.

## 동등성 검증

- **miomock 21개 테이블 전수 비교 → 결과 완전 동일** (ManyToMany 조인테이블 포함)
- **deti 75개 테이블 전수 비교 → 결과 완전 동일**
- miomock 통합 테스트 **1415 passed**
- `mise run check` / `tsc --noEmit` / `test:type` 통과

`package.json`: `0.11.1` → `0.11.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)