### PR TITLE
perf(migration): 스키마 조회를 테이블별에서 일괄 조회로 전환

### DIFF
--- a/examples/miomock/api/src/sonamu-test/migrator.generatedColumn.test.ts
+++ b/examples/miomock/api/src/sonamu-test/migrator.generatedColumn.test.ts
@@ -383,8 +383,8 @@ describe("Migrator - Generated Column", () => {
       ),
     } satisfies EntityJson;
 
-    const originalGetMigrationSetFromDB =
-      PostgreSQLSchemaReader.getMigrationSetFromDB.bind(PostgreSQLSchemaReader);
+    const originalGetMigrationSetFromDBAll =
+      PostgreSQLSchemaReader.getMigrationSetFromDBAll.bind(PostgreSQLSchemaReader);
     const originalGetByTable = EntityManager.getByTable.bind(EntityManager);
     const dbSet = buildDbSetWithGeneratedSearchText(
       getMigrationSetFromEntity(new Entity(previousUser)),
@@ -400,13 +400,12 @@ describe("Migrator - Generated Column", () => {
       return originalGetByTable(table);
     });
     const schemaReaderSpy = vi
-      .spyOn(PostgreSQLSchemaReader, "getMigrationSetFromDB")
-      .mockImplementation(async (compareDB, table) => {
-        if (table === "users") {
-          return dbSet;
-        }
-
-        return originalGetMigrationSetFromDB(compareDB, table);
+      .spyOn(PostgreSQLSchemaReader, "getMigrationSetFromDBAll")
+      .mockImplementation(async (compareDB) => {
+        // users만 합성 dbSet으로 바꾸고 나머지 테이블은 실제 스키마를 그대로 쓴다.
+        const dbSets = await originalGetMigrationSetFromDBAll(compareDB);
+        dbSets.set("users", dbSet);
+        return dbSets;
       });
 
     try {
@@ -481,8 +480,8 @@ describe("Migrator - Generated Column", () => {
       ),
     } satisfies EntityJson;
 
-    const originalGetMigrationSetFromDB =
-      PostgreSQLSchemaReader.getMigrationSetFromDB.bind(PostgreSQLSchemaReader);
+    const originalGetMigrationSetFromDBAll =
+      PostgreSQLSchemaReader.getMigrationSetFromDBAll.bind(PostgreSQLSchemaReader);
     const originalGetByTable = EntityManager.getByTable.bind(EntityManager);
     const dbSet = buildDbSetWithGeneratedSearchText(
       getMigrationSetFromEntity(new Entity(previousUser)),
@@ -498,13 +497,12 @@ describe("Migrator - Generated Column", () => {
       return originalGetByTable(table);
     });
     const schemaReaderSpy = vi
-      .spyOn(PostgreSQLSchemaReader, "getMigrationSetFromDB")
-      .mockImplementation(async (compareDB, table) => {
-        if (table === "users") {
-          return dbSet;
-        }
-
-        return originalGetMigrationSetFromDB(compareDB, table);
+      .spyOn(PostgreSQLSchemaReader, "getMigrationSetFromDBAll")
+      .mockImplementation(async (compareDB) => {
+        // users만 합성 dbSet으로 바꾸고 나머지 테이블은 실제 스키마를 그대로 쓴다.
+        const dbSets = await originalGetMigrationSetFromDBAll(compareDB);
+        dbSets.set("users", dbSet);
+        return dbSets;
       });
 
     try {
@@ -565,8 +563,8 @@ describe("Migrator - Generated Column", () => {
       indexes: previousUser.indexes.filter((index) => index.name !== "users_search_text_trgm"),
     } satisfies EntityJson;
 
-    const originalGetMigrationSetFromDB =
-      PostgreSQLSchemaReader.getMigrationSetFromDB.bind(PostgreSQLSchemaReader);
+    const originalGetMigrationSetFromDBAll =
+      PostgreSQLSchemaReader.getMigrationSetFromDBAll.bind(PostgreSQLSchemaReader);
     const originalGetByTable = EntityManager.getByTable.bind(EntityManager);
     const dbSet = buildDbSetWithGeneratedSearchText(
       getMigrationSetFromEntity(new Entity(previousUser)),
@@ -582,13 +580,12 @@ describe("Migrator - Generated Column", () => {
       return originalGetByTable(table);
     });
     const schemaReaderSpy = vi
-      .spyOn(PostgreSQLSchemaReader, "getMigrationSetFromDB")
-      .mockImplementation(async (compareDB, table) => {
-        if (table === "users") {
-          return dbSet;
-        }
-
-        return originalGetMigrationSetFromDB(compareDB, table);
+      .spyOn(PostgreSQLSchemaReader, "getMigrationSetFromDBAll")
+      .mockImplementation(async (compareDB) => {
+        // users만 합성 dbSet으로 바꾸고 나머지 테이블은 실제 스키마를 그대로 쓴다.
+        const dbSets = await originalGetMigrationSetFromDBAll(compareDB);
+        dbSets.set("users", dbSet);
+        return dbSets;
       });
 
     try {

--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/migration/migrator.ts
+++ b/modules/sonamu/src/migration/migrator.ts
@@ -669,13 +669,14 @@ export class Migrator {
     const codes: GenMigrationCode[] = [];
     const batchSize = 4;
 
+    // 테이블마다 스키마를 조회하면 왕복이 테이블 수에 비례해 늘어난다.
+    // 종류별로 한 번씩만 읽어두고 아래에서 테이블명으로 찾아 쓴다.
+    const dbSets = await PostgreSQLSchemaReader.getMigrationSetFromDBAll(compareDB);
+
     for (let i = 0; i < entitySets.length; i += batchSize) {
       const batchCodes = await Promise.all(
         entitySets.slice(i, i + batchSize).map(async (entitySet) => {
-          const dbSet = await PostgreSQLSchemaReader.getMigrationSetFromDB(
-            compareDB,
-            entitySet.table,
-          );
+          const dbSet = dbSets.get(entitySet.table) ?? null;
           Naite.t(`migrator:compareMigrations:entitySet:${entitySet.table}`, entitySet);
           Naite.t(`migrator:compareMigrations:dbSet:${entitySet.table}`, dbSet);
 

--- a/modules/sonamu/src/migration/postgresql-schema-reader.ts
+++ b/modules/sonamu/src/migration/postgresql-schema-reader.ts
@@ -68,6 +68,12 @@ type PgForeign = {
   delete_rule: string;
 };
 
+type TableSchemaRows = {
+  columns: PgColumn[];
+  indexes: PgIndex[];
+  foreigns: PgForeign[];
+};
+
 type RawCapableKnex = Pick<Knex, "raw">;
 
 class PostgreSQLSchemaReaderClass {
@@ -96,6 +102,53 @@ class PostgreSQLSchemaReaderClass {
     // vector 컬럼의 dimensions 조회
     const vectorDimensions = await this.getVectorDimensions(compareDB, table);
 
+    return this.buildMigrationSet(table, dbColumns, dbIndexes, dbForeigns, vectorDimensions);
+  }
+
+  /**
+   * public 스키마의 모든 테이블을 한 번에 읽어서 테이블별 MigrationSet을 반환합니다.
+   *
+   * getMigrationSetFromDB를 테이블마다 호출하면 (컬럼/인덱스/FK/벡터차원) × 테이블 수 만큼
+   * 왕복이 발생한다. 비교 대상이 수십 개면 원격 DB에서 왕복 비용이 지배적이 되므로,
+   * 종류별로 한 번씩만 조회한다. 행 해석은 getMigrationSetFromDB와 동일한
+   * buildMigrationSet을 공유한다.
+   *
+   * @returns 테이블명 → MigrationSet. DB에 없는 테이블은 항목이 없다.
+   */
+  async getMigrationSetFromDBAll(compareDB: RawCapableKnex): Promise<Map<string, MigrationSet>> {
+    const [tables, vectorDimensions] = await Promise.all([
+      this.readTables(compareDB),
+      this.getVectorDimensionsAll(compareDB),
+    ]);
+
+    const migrationSets = new Map<string, MigrationSet>();
+    for (const [table, rows] of tables) {
+      migrationSets.set(
+        table,
+        this.buildMigrationSet(
+          table,
+          rows.columns,
+          rows.indexes,
+          rows.foreigns,
+          vectorDimensions.get(table) ?? {},
+        ),
+      );
+    }
+    return migrationSets;
+  }
+
+  /**
+   * 조회 결과 행들을 MigrationSet으로 변환합니다.
+   * 테이블 단위 조회(getMigrationSetFromDB)와 전체 일괄 조회(getMigrationSetFromDBAll)가
+   * 이 로직을 공유합니다.
+   */
+  private buildMigrationSet(
+    table: string,
+    dbColumns: PgColumn[],
+    dbIndexes: PgIndex[],
+    dbForeigns: PgForeign[],
+    vectorDimensions: Record<string, number>,
+  ): MigrationSet {
     const columns: MigrationColumn[] = dbColumns.map((dbColumn) => {
       const dbColType = this.resolveDBColType(dbColumn);
 
@@ -257,9 +310,32 @@ class PostgreSQLSchemaReaderClass {
     compareDB: RawCapableKnex,
     tableName: string,
   ): Promise<[PgColumn[], PgIndex[], PgForeign[]]> {
+    const tables = await this.readTables(compareDB, tableName);
+    const rows = tables.get(tableName);
+    if (rows === undefined) {
+      throw new Error(`Table not found: ${tableName}`);
+    }
+    return [rows.columns, rows.indexes, rows.foreigns];
+  }
+
+  /**
+   * public 스키마 테이블들의 cols/indexes/foreigns를 테이블별로 묶어서 반환합니다.
+   *
+   * tableName을 주면 그 테이블만, 생략하면 전체를 조회합니다. 쿼리는 두 경로가 공유하므로
+   * 단일 조회와 일괄 조회의 해석이 갈라지지 않습니다. 전체 조회 시에는 테이블마다 4번씩
+   * 왕복하는 대신 종류별로 한 번씩만 돌기 때문에, 원격 DB에서 왕복 비용이 크게 줄어듭니다.
+   */
+  private async readTables(
+    compareDB: RawCapableKnex,
+    tableName?: string,
+  ): Promise<Map<string, TableSchemaRows>> {
+    const bindings = tableName === undefined ? [] : [tableName, tableName, tableName];
+    const tableFilter = (column: string) => (tableName === undefined ? "" : `AND ${column} = ?`);
+
     // Columns 조회 (Generated Column 정보 포함)
     const columnsQuery = `
       SELECT
+        c.table_name,
         c.column_name,
         c.data_type,
         c.udt_name,
@@ -282,20 +358,15 @@ class PostgreSQLSchemaReaderClass {
           SELECT oid FROM pg_class WHERE relname = c.table_name
           AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = c.table_schema)
         )
-      WHERE c.table_name = ?
-        AND c.table_schema = 'public'
-      ORDER BY c.ordinal_position
+      WHERE c.table_schema = 'public'
+        ${tableFilter("c.table_name")}
+      ORDER BY c.table_name, c.ordinal_position
     `;
-    const columns = /* SAFETY: Knex와 PostgreSQL 스키마 조회 계약이 이 값의 타입을 보장한다. */ (
-      await compareDB.raw(columnsQuery, [tableName])
-    ).rows as PgColumn[];
-    if (columns.length === 0) {
-      throw new Error(`Table not found: ${tableName}`);
-    }
 
     // Indexes 조회 (PGroonga 표현식 인덱스 포함)
     const indexesQuery = `
       SELECT
+          t.relname AS table_name,
           i.relname AS index_name,
           CASE
               WHEN am.amname = 'pgroonga' AND u.attnum = 0 THEN
@@ -325,6 +396,7 @@ class PostgreSQLSchemaReaderClass {
           pg_get_indexdef(ix.indexrelid) AS index_definition,
           pg_get_expr(ix.indpred, ix.indrelid) AS predicate
       FROM pg_class t
+      JOIN pg_namespace ns ON ns.oid = t.relnamespace
       JOIN pg_index ix ON t.oid = ix.indrelid
       JOIN pg_class i ON i.oid = ix.indexrelid
       JOIN pg_am am ON i.relam = am.oid
@@ -334,9 +406,11 @@ class PostgreSQLSchemaReaderClass {
           AND a.attnum = u.attnum 
           AND u.attnum > 0
       LEFT JOIN LATERAL (
-          SELECT 
-              unnest(
-                  CASE 
+          -- PGroonga 표현식 인덱스는 모든 행의 attnum이 0이라 u.ord가 같다.
+          -- 표현식 배열의 순번(expr_ord)을 함께 뽑아 정렬을 확정한다.
+          SELECT expr.column_expr, expr.expr_ord
+          FROM unnest(
+                  CASE
                       WHEN pg_get_expr(ix.indexprs, ix.indrelid) ~ '^ARRAY\\[' THEN
                           string_to_array(
                               regexp_replace(
@@ -349,13 +423,14 @@ class PostgreSQLSchemaReaderClass {
                       ELSE
                           ARRAY[pg_get_expr(ix.indexprs, ix.indrelid)]
                   END
-              ) as column_expr
+              ) WITH ORDINALITY AS expr(column_expr, expr_ord)
       ) pgroonga_col ON am.amname = 'pgroonga' AND u.attnum = 0
-      WHERE t.relname = ?
+      WHERE t.relkind = 'r'
+          AND ns.nspname = 'public'
+          ${tableFilter("t.relname")}
           AND (u.attnum > 0 OR (am.amname = 'pgroonga' AND u.attnum = 0))
-      ORDER BY i.relname, u.ord;
+      ORDER BY t.relname, i.relname, u.ord, pgroonga_col.expr_ord;
 `;
-    const indexes = (await compareDB.raw(indexesQuery, [tableName])).rows;
 
     // Foreign Keys 조회
     //
@@ -371,6 +446,7 @@ class PostgreSQLSchemaReaderClass {
     // 짝지어야 복합 FK에서 컬럼 대응이 어긋나지 않는다.
     const foreignsQuery = `
       SELECT
+        cl.relname AS table_name,
         con.conname AS constraint_name,
         att.attname AS column_name,
         ref_cl.relname AS foreign_table_name,
@@ -402,12 +478,46 @@ class PostgreSQLSchemaReaderClass {
         ON ref_att.attrelid = ref_cl.oid AND ref_att.attnum = ref_key_col.attnum
       WHERE con.contype = 'f'
         AND ns.nspname = 'public'
-        AND cl.relname = ?
-      ORDER BY con.conname, key_col.ord
+        ${tableFilter("cl.relname")}
+      ORDER BY cl.relname, con.conname, key_col.ord
     `;
-    const foreigns = (await compareDB.raw(foreignsQuery, [tableName])).rows;
 
-    return [columns, indexes, foreigns];
+    // 종류별로 한 번씩만 조회한 뒤 테이블명으로 묶습니다.
+    const [columnRows, indexRows, foreignRows] = await Promise.all([
+      compareDB
+        .raw(columnsQuery, bindings.slice(0, 1))
+        .then((result: { rows: (PgColumn & { table_name: string })[] }) => result.rows),
+      compareDB
+        .raw(indexesQuery, bindings.slice(1, 2))
+        .then((result: { rows: (PgIndex & { table_name: string })[] }) => result.rows),
+      compareDB
+        .raw(foreignsQuery, bindings.slice(2, 3))
+        .then((result: { rows: (PgForeign & { table_name: string })[] }) => result.rows),
+    ]);
+
+    const tables = new Map<string, TableSchemaRows>();
+    const ensure = (table: string): TableSchemaRows => {
+      const existing = tables.get(table);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const created: TableSchemaRows = { columns: [], indexes: [], foreigns: [] };
+      tables.set(table, created);
+      return created;
+    };
+
+    // 컬럼이 없는 테이블은 존재하지 않는 것으로 취급하므로 컬럼 기준으로 항목을 만듭니다.
+    for (const row of columnRows) {
+      ensure(row.table_name).columns.push(row);
+    }
+    for (const row of indexRows) {
+      tables.get(row.table_name)?.indexes.push(row);
+    }
+    for (const row of foreignRows) {
+      tables.get(row.table_name)?.foreigns.push(row);
+    }
+
+    return tables;
   }
 
   private restoreMigrationIndexType(
@@ -788,24 +898,41 @@ class PostgreSQLSchemaReaderClass {
     compareDB: RawCapableKnex,
     tableName: string,
   ): Promise<Record<string, number>> {
+    return (await this.getVectorDimensionsAll(compareDB, tableName)).get(tableName) ?? {};
+  }
+
+  /**
+   * vector 컬럼의 dimensions를 테이블별로 조회합니다.
+   * tableName을 생략하면 public 스키마 전체를 한 번에 조회합니다.
+   */
+  private async getVectorDimensionsAll(
+    compareDB: RawCapableKnex,
+    tableName?: string,
+  ): Promise<Map<string, Record<string, number>>> {
     const query = `
       SELECT
+        c.relname as table_name,
         a.attname as column_name,
         a.atttypmod as dimensions
       FROM pg_attribute a
       JOIN pg_class c ON a.attrelid = c.oid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
       JOIN pg_type t ON a.atttypid = t.oid
-      WHERE c.relname = ?
-        AND t.typname = 'vector'
+      WHERE t.typname = 'vector'
         AND a.attnum > 0
+        AND n.nspname = 'public'
+        ${tableName === undefined ? "" : "AND c.relname = ?"}
     `;
-    const result = await compareDB.raw(query, [tableName]);
-    const dimensions: Record<string, number> = {};
+    const result = await compareDB.raw(query, tableName === undefined ? [] : [tableName]);
+
+    const dimensionsByTable = new Map<string, Record<string, number>>();
     for (const row of result.rows) {
+      const dimensions = dimensionsByTable.get(row.table_name) ?? {};
       // atttypmod에서 실제 dimensions 값 추출
       dimensions[row.column_name] = row.dimensions > 0 ? row.dimensions : 0;
+      dimensionsByTable.set(row.table_name, dimensions);
     }
-    return dimensions;
+    return dimensionsByTable;
   }
 
   /**


### PR DESCRIPTION
## 배경

FK 쿼리를 `pg_constraint`로 바꾼 뒤(#247)에도 `prepared-codes`가 **2.13초**였다. 남은 비용은 쿼리 자체가 아니라 **왕복 횟수**다.

비교 대상 테이블마다 컬럼/인덱스/FK/벡터차원을 4번씩 조회하므로 75테이블이면 **300회 왕복**한다. 그런데 **필터는 비용이 아니다** — FK 조회는 1테이블이든 75테이블 전체든 33ms로 같다.

| 조회 | 테이블마다 (75회) | 전체 1회 |
| :-- | --: | --: |
| 컬럼 | 1,535ms | 130ms |
| 인덱스 | ~900ms | 9ms |
| FK | 1,790ms | 33ms |

## 변경

`getMigrationSetFromDBAll`을 추가하고 `compareMigrations`가 이를 쓴다. **로직은 기존 경로와 공유**한다.

- `readTable` → `readTables`로 일반화. 테이블명을 주면 그 테이블만, 생략하면 전체. **쿼리 본문을 두 경로가 공유**하므로 해석이 갈라지지 않는다.
- 행 → `MigrationSet` 변환을 `buildMigrationSet`으로 분리해 공유.
- 기존 `getMigrationSetFromDB`는 **시그니처·동작 유지**.

### 함께 고친 것

**인덱스 조회에 스키마/relkind 조건 명시** — 테이블명만으로 거르면 다른 스키마의 동명 테이블이 딸려올 수 있다. 일괄 조회에서는 그대로 드러나므로 `nspname='public'`, `relkind='r'`을 넣었다.

**PGroonga 표현식 인덱스의 컬럼 순서 비결정성** — 표현식 인덱스는 모든 행의 `attnum`이 0이라 `u.ord`가 같아 정렬이 미정의였다. 실제로 동등성 검증에서 `projects`의 컬럼 순서가 단일/일괄 간에 갈렸다(`[name, description]` vs `[description, name]`). 표현식 배열의 순번을 `WITH ORDINALITY`로 뽑아 정렬에 사용하도록 확정했다.

## 측정

| | 전 | 후 |
| :-- | --: | --: |
| **deti** (원격, 76테이블) | 4,016ms | **142ms** (약 28배) |
| miomock (로컬, 21테이블) | 123ms | **43ms** |

## 동등성 검증

테이블별 조회 결과와 **JSON 전문을 비교**했다.

- **miomock 21개 테이블 불일치 0**
- **deti 76개 테이블 불일치 0**
- miomock 통합 테스트 **1415 passed**
- `mise run check` / `tsc --noEmit` / `test:type` 통과

`migrator.generatedColumn.test.ts`는 목킹 지점이 `getMigrationSetFromDBAll`로 옮겨가 함께 수정했다(users만 합성 dbSet, 나머지는 실제 스키마 — 기존 의도 그대로).

`package.json`: `0.11.2` → `0.11.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)