### PR TITLE
fix(scaffold): CLI 스캐폴딩에서도 필수 dict 키를 등록

### DIFF
--- a/modules/sonamu/package.json
+++ b/modules/sonamu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonamu",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Sonamu — TypeScript Fullstack API Framework",
   "keywords": [
     "framework",

--- a/modules/sonamu/src/tooling/cli-tooling.ts
+++ b/modules/sonamu/src/tooling/cli-tooling.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { type FixtureCommandOptions } from "../bin/fixture";
+import { type TemplateKey } from "../types/types";
 
 const jsonValueSchema = z.json();
 type CommandValue = z.infer<typeof jsonValueSchema> | undefined;
@@ -323,6 +324,29 @@ async function renderScaffolds(input: CommandInput) {
   return rendered;
 }
 
+/**
+ * 템플릿이 요구하는 dict 키를 프로젝트 사전에 채웁니다.
+ *
+ * 생성 코드에는 SD("error.entityNotFound") 같은 호출이 박히는데, 키가 프로젝트 사전에
+ * 없으면 번역이 되지 않아 사람이 매번 손으로 채우거나 다른 키로 바꿔야 한다.
+ * Sonamu UI 경로(ui/api.ts)는 이미 같은 처리를 하므로, CLI도 동일하게 맞춘다.
+ */
+async function ensureTemplateDictKeys(templateKeys: TemplateKey[]): Promise<void> {
+  const [{ TemplateManager }, { sonamuDictionary }] = await Promise.all([
+    import("../template/template-manager"),
+    import("../dict/sonamu-dictionary"),
+  ]);
+
+  const requiredKeys = templateKeys.flatMap(
+    (templateKey) => TemplateManager.get(templateKey).getRequiredDictKeys() ?? [],
+  );
+  if (requiredKeys.length === 0) {
+    return;
+  }
+
+  await sonamuDictionary.ensureDictKeys([...new Set(requiredKeys)]);
+}
+
 async function scaffoldOperation(method: string, input: CommandInput): Promise<ToolingResult> {
   const directTemplate = z
     .enum(["model", "model_test", "view_list", "view_form"])
@@ -331,6 +355,7 @@ async function scaffoldOperation(method: string, input: CommandInput): Promise<T
     await ensureSonamu();
     const { Sonamu } = await import("../api/sonamu");
     const entityId = requiredText(input, "entityId");
+    await ensureTemplateDictKeys([directTemplate.data]);
     return directTemplate.data === "view_list"
       ? Sonamu.syncer.generateTemplate("view_list", { entityId, extra: input.extra })
       : Sonamu.syncer.generateTemplate(directTemplate.data, { entityId });
@@ -358,6 +383,9 @@ async function scaffoldOperation(method: string, input: CommandInput): Promise<T
   );
   if (method === "status") return items.map(({ content: _content, ...item }) => item);
   if (method === "preview" || (method === "batch" && explicitlyDryRun(input))) return items;
+
+  // 실제로 파일을 쓰는 경우에만 사전을 건드린다(status/preview/dry-run은 위에서 반환됨).
+  await ensureTemplateDictKeys([...new Set(items.map((item) => item.template))]);
 
   const results = [];
   for (const item of items) {


### PR DESCRIPTION
## 문제

`model` 템플릿은 생성 코드에 이 SD 호출을 넣고, `getRequiredDictKeys()`로도 선언한다.

```ts
SD("error.entityNotFound")("Tag", id)
SD("error.unknownSearchField")(params.search)
```

그런데 **선언된 키를 프로젝트 사전에 채우는 `ensureDictKeys` 호출이 Sonamu UI 경로(`ui/api.ts:863`)에만** 있었다. CLI 경로(`tooling/cli-tooling.ts`의 `scaffoldOperation`)는 곧바로 `generateTemplate`만 부른다.

→ **CLI로 스캐폴딩하면 코드에는 SD 호출이 박히는데 사전에는 키가 안 생긴다.** 에이전트는 주로 CLI를 쓰므로 매번 이 경로를 탄다.

실제로 어떤 프로젝트에서는 스캐폴딩할 때마다 사람이 손으로 고치고 있었다:

```ts
// ⚠️ 스캐폴드 산물은 `error.entityNotFound` 를 쓰는데 이 저장소 사전에 없는 키다.
// SD 사전에 unknownSearchField 키가 없어 공용 badRequest 로.
```

## 변경

`ensureTemplateDictKeys` 헬퍼를 추가해 UI와 동일하게 처리한다.

- 단일 템플릿 경로(`scaffold model` 등)와 **batch 경로 모두** 적용
- `status` / `preview` / dry-run은 파일을 쓰지 않으므로 **사전도 건드리지 않는다**

`package.json`: `0.11.3` → `0.11.4`

## 검증 (miomock — 두 키가 없던 상태에서 시작)

| 실행 | 사전 변화 |
| :-- | :-- |
| `sonamu scaffold model Tag` | `error.entityNotFound`, `error.unknownSearchField` **자동 등록됨** ✅ |
| `sonamu scaffold status --entity Tag --template model` | **변경 없음** ✅ |

- `defaultLocale`(ko)에만 추가 — `ensureDictKeys` 기존 동작 그대로
- miomock 통합 테스트 **1415 passed**
- `mise run check` / `tsc --noEmit` / `test:type` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)